### PR TITLE
完善 simple-matching 的交互

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -20,7 +20,7 @@
     "classnames": "^2.2.5",
     "file-saver": "^1.3.8",
     "immutable": "^4.0.0-rc.9",
-    "little-saga": "^0.4.2",
+    "little-saga": "^0.4.3",
     "moment": "^2.22.2",
     "normalize.css": "^8.0.0",
     "pegjs": "^0.10.0",

--- a/packages/frontend/src/sagas/handleUserInteractions.ts
+++ b/packages/frontend/src/sagas/handleUserInteractions.ts
@@ -63,7 +63,7 @@ function* handleUserAnnotateCurrent({ tag }: Action.UserAnnotateCurrent) {
   if (editor.range) {
     collector.userAnnotateText(editor.range, tag)
   } else {
-    collector.userAnnotateSel(editor.sel, tag)
+    collector.userAnnotateSel(selection, tag)
   }
   yield applyEditorAction(new Annotate(keyed(annotating), tag))
 }

--- a/packages/frontend/src/utils/InteractionCollector.ts
+++ b/packages/frontend/src/utils/InteractionCollector.ts
@@ -25,7 +25,7 @@ export namespace Interaction {
 
   export interface UserAnnotateSel {
     type: 'USER_ANNOTATE_SEL'
-    sel: Set<string>
+    selection: Set<Decoration>
     tag: string
   }
 
@@ -61,8 +61,8 @@ export default class InteractionCollector {
     this.channel.put({ type: 'USER_DELETE_DECORATIONS', set })
   }
 
-  userAnnotateSel(sel: Set<string>, tag: string) {
-    this.channel.put({ type: 'USER_ANNOTATE_SEL', sel, tag })
+  userAnnotateSel(selection: Set<Decoration>, tag: string) {
+    this.channel.put({ type: 'USER_ANNOTATE_SEL', selection, tag })
   }
 
   userAcceptHints(set: Set<Hint>) {

--- a/packages/frontend/yarn.lock
+++ b/packages/frontend/yarn.lock
@@ -4690,9 +4690,9 @@ listr@^0.14.1:
     rxjs "^6.1.0"
     strip-ansi "^3.0.1"
 
-little-saga@^0.4.2:
-  version "0.4.2"
-  resolved "http://registry.npm.taobao.org/little-saga/download/little-saga-0.4.2.tgz#2e278e34362044f0bf92500cc3df99eed5f91e1a"
+little-saga@^0.4.3:
+  version "0.4.3"
+  resolved "http://registry.npm.taobao.org/little-saga/download/little-saga-0.4.3.tgz#c766c94fc202d1d064d184fd7f69948456cc390d"
   dependencies:
     "@types/node" "^10.5.2"
 


### PR DESCRIPTION
完善 simple-matching 的交互：重新标注的时候会修改已有的提示对象。例如，假设我们给「中国」搭上了「地点」的标签，文档中出现了 n 个提示，在这些提示被接受之前，如果我们对「文本为中国的修饰对象」进行标注，或是重新对给「中国」文本打上标签，**这些提示对象的内容会同步修改**。
Fix #3